### PR TITLE
SysUI: Fix hiding per-app sensitive notifications

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
@@ -4749,8 +4749,8 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
     public void updateStackScrollerState(boolean goingToFullShade) {
         if (mStackScroller == null) return;
         boolean onKeyguard = mState == StatusBarState.KEYGUARD;
-        mStackScroller.setHideSensitive(onKeyguard
-                && !userAllowsPrivateNotificationsInPublic(mCurrentUserId), goingToFullShade);
+        mStackScroller.setHideSensitive(isLockscreenPublicMode()
+                || !userAllowsPrivateNotificationsInPublic(mCurrentUserId), goingToFullShade);
         mStackScroller.setDimmed(onKeyguard, false /* animate */);
         mStackScroller.setExpandingEnabled(!onKeyguard);
         ActivatableNotificationView activatedChild = mStackScroller.getActivatedChild();


### PR DESCRIPTION
This fixes an issue introduced in Ic0f6e01cf7c09d4f8ed7e8735158a6fc093b8dcc
where the user has show all notifications enabled and has turned
on hiding of sensitive notifications for specific apps, but those
notifications still show all content.

Change-Id: Ia00a6acdacfa81e0b54224655c3d81d6a4f56518
TICKET: CYNGNOS-2176
(cherry picked from commit 4fa29056b5ffa00400764a5053b78c9ad1f2e6f6)